### PR TITLE
3 バグを修正優先️⬆️

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KotlinJpsPluginSettings">
+    <option name="version" value="1.6.21" />
+  </component>
+</project>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.6.21" />
-  </component>
-</project>

--- a/app/src/main/res/layout/fragment_one.xml
+++ b/app/src/main/res/layout/fragment_one.xml
@@ -10,7 +10,6 @@
         android:id="@+id/searchBar"
         android:layout_width="0dp"
         android:layout_height="?attr/actionBarSize"
-        android:layout_margin="12dp"
         android:layout_marginStart="12dp"
         android:layout_marginEnd="12dp"
         app:cardCornerRadius="12dp"

--- a/app/src/main/res/layout/fragment_one.xml
+++ b/app/src/main/res/layout/fragment_one.xml
@@ -11,6 +11,8 @@
         android:layout_width="0dp"
         android:layout_height="?attr/actionBarSize"
         android:layout_margin="12dp"
+        android:layout_marginStart="12dp"
+        android:layout_marginEnd="12dp"
         app:cardCornerRadius="12dp"
         app:cardElevation="8dp"
         app:layout_constraintBottom_toTopOf="@id/recyclerView"
@@ -20,7 +22,7 @@
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/searchInputLayout"
-            style="@style/TextInputLayoutNoBorder"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:importantForAutofill="no"
@@ -48,15 +50,16 @@
 
     </com.google.android.material.card.MaterialCardView>
 
+
     <!-- 検索ボタンの追加 -->
     <Button
         android:id="@+id/searchButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
         android:text="@string/search_button_text"
         app:layout_constraintEnd_toEndOf="@id/searchBar"
-        app:layout_constraintTop_toBottomOf="@id/searchBar"
-        android:layout_marginTop="8dp"/>
+        app:layout_constraintTop_toBottomOf="@id/searchBar" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerView"
@@ -68,5 +71,6 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/searchButton"
         app:layout_constraintVertical_bias="0.0" />
+
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/layout_item.xml
+++ b/app/src/main/res/layout/layout_item.xml
@@ -7,7 +7,7 @@
 
     <TextView
         android:id="@+id/repositoryNameView"
-        android:layout_width="0dp"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="16dp"
         android:layout_marginVertical="8dp"


### PR DESCRIPTION
### 概要 
[3 バグを修正 #3  ](https://github.com/asithishantha/android-engineer-codecheck-asith/issues/3)に関連

このPull Requestでは、以下の問題点に対処し、アプリケーションの安定性とユーザーエクスペリエンスを向上させました。

[改善された問題点]

レイアウトエラー: ユーザーインターフェースの一貫性を保つために、レイアウトのマージンを調整しました。
メモリリーク: OneFragmentのViewBindingリソースを適切に解放することで、メモリリークを防止しました。
パースエラー: JSONのパース処理におけるエラーハンドリングを追加し、アプリの安定性を向上させました。
例外の処理漏れ: エラー発生時の例外処理を追加し、アプリのクラッシュを防止しました。
クラッシュ: ユーザー操作によるクラッシュリスクを低減するために、例外処理を強化しました。

**コード変更点とスクリーンショットの案内**

**レイアウトエラーの修正**: fragment_one.xmlでMaterialCardViewのマージンを調整しました。
    スクリーンショット対象: fragment_one.xmlのMaterialCardView部分
<img width="468" alt="レイアウトエラーの修正" src="https://github.com/asithishantha/android-engineer-codecheck-asith/assets/42315166/6994543f-66a9-49a5-8d22-210e699dfdca">


**メモリリークの防止**: OneFragment.ktのonDestroyViewメソッドでViewBindingをnullに設定しました。
    スクリーンショット対象: OneFragment.ktのonDestroyViewメソッド
<img width="664" alt="メモリリークの防止" src="https://github.com/asithishantha/android-engineer-codecheck-asith/assets/42315166/dc0f96e0-41a5-434c-b6f6-87a68730173c">

**パースエラーのハンドリング**: OneFragment.ktで検索結果のパース処理にエラーハンドリングを追加しました。
   スクリーンショット対象: OneViewModel.ktのsearchResultsメソッド
<img width="781" alt="パースエラーのハンドリング" src="https://github.com/asithishantha/android-engineer-codecheck-asith/assets/42315166/3e738fd6-ab73-4a4a-ae1a-9f66b77beda8">

**クラッシュリスクの低減**: OneFragment.ktでアイテムクリック時の例外処理を追加しました。
    スクリーンショット対象: OneFragment.ktのCustomAdapter初期化部分
<img width="656" alt="クラッシュリスクの低減" src="https://github.com/asithishantha/android-engineer-codecheck-asith/assets/42315166/ea3ee37d-b326-451a-b747-128900f6d005">

これらの変更がアプリの品質向上に大きく貢献することを期待しています。