### PR TITLE
AndroidManifestにHiltAndroidAppクラスを追加優先⬇️

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ lint/tmp/
 
 # Android Profiling
 *.hprof
+.idea/kotlinc.xml

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KotlinJpsPluginSettings">
+    <option name="version" value="1.6.21" />
+  </component>
+</project>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.6.21" />
-  </component>
-</project>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     
     <application
+        android:name=".GithubSearchApp"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"


### PR DESCRIPTION
**内容:**
このプルリクエストでは、AndroidManifest.xmlに`HiltAndroidApp`アノテーションが付いたアプリケーションクラスを指定する変更を加えました。以前はこの設定が抜けていたため、Hiltの依存注入が正しく機能していませんでした。`HiltAndroidApp`はHiltが依存注入を行うために必要なアプリケーションのライフサイクルを管理するため、この追加はアプリケーションの正常な動作に不可欠です。この変更により、Hiltを使用した依存注入が期待通りに動作するようになります。